### PR TITLE
[WIP] Use a cookie to help invalidate cache

### DIFF
--- a/lib/ood/user_map.lua
+++ b/lib/ood/user_map.lua
@@ -11,8 +11,11 @@ function map(r, user_map_cmd)
   -- read in cached user if available
   local sys_user = r:ivm_get("user_cache_" .. auth_user)
 
+  -- read in cookie with suggested system user
+  local tmp_sys_user = r:getcookie("mod_ood_proxy_session")
+
   -- if no cached user, then find system user and cache it
-  if not sys_user then
+  if not sys_user or not tmp_sys_user or sys_user ~= tmp_sys_user then
     -- run user_map_cmd and read in stdout
     local handle = io.popen(user_map_cmd .. " '" .. auth_user .. "'")
     sys_user = handle:read()
@@ -25,6 +28,13 @@ function map(r, user_map_cmd)
 
     -- cache system user
     r:ivm_set("user_cache_" .. auth_user, sys_user)
+    r:setcookie{
+      key = "mod_ood_proxy_session",
+      value = sys_user,
+      expires = os.time() + 28800,
+      httponly = true,
+      secure = true
+    }
   end
 
   return sys_user


### PR DESCRIPTION
Fixes #1

Checks for existence of cookie to determine whether local cache is invalid. It also compares the value in the cookie to the local cache value as added precaution.
