### PR TITLE
Removed user map caching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Features:
 
   - added sequence diagram to `README.md`
+  - removed user map caching and made mapping more verbose
 
 ## 0.0.2 (2016-08-04)
 

--- a/lib/ood/user_map.lua
+++ b/lib/ood/user_map.lua
@@ -8,33 +8,16 @@ function map(r, user_map_cmd)
   -- read in authenticated user
   local auth_user = r:escape(r.user)
 
-  -- read in cached user if available
-  local sys_user = r:ivm_get("user_cache_" .. auth_user)
+  -- run user_map_cmd and read in stdout
+  local now = r:clock()
+  local handle = io.popen(user_map_cmd .. " '" .. auth_user .. "'")
+  sys_user = handle:read()
+  handle:close()
+  r:info("Mapped '" .. r.user .. "' => '" .. (sys_user or "") .. "' [" .. (r:clock() - now)/1000.0 .. " ms]")
 
-  -- read in cookie with suggested system user
-  local tmp_sys_user = r:getcookie("mod_ood_proxy_session")
-
-  -- if no cached user, then find system user and cache it
-  if not sys_user or not tmp_sys_user or sys_user ~= tmp_sys_user then
-    -- run user_map_cmd and read in stdout
-    local handle = io.popen(user_map_cmd .. " '" .. auth_user .. "'")
-    sys_user = handle:read()
-    handle:close()
-
-    -- failed to map if returns empty string
-    if not sys_user or sys_user == "" then
-      return nil
-    end
-
-    -- cache system user
-    r:ivm_set("user_cache_" .. auth_user, sys_user)
-    r:setcookie{
-      key = "mod_ood_proxy_session",
-      value = sys_user,
-      expires = os.time() + 28800,
-      httponly = true,
-      secure = true
-    }
+  -- failed to map if returns empty string
+  if not sys_user or sys_user == "" then
+    return nil
   end
 
   return sys_user


### PR DESCRIPTION
Changes:
- removed user map caching due to no discernible speed up
- made logs more verbose when mapping user

Fixes #3 as there is no more cache to invalidate.
